### PR TITLE
make possible to create BitSetIntIterable from any Integer collection

### DIFF
--- a/iabtcf-decoder/src/main/java/com/iabtcf/utils/BitSetIntIterable.java
+++ b/iabtcf-decoder/src/main/java/com/iabtcf/utils/BitSetIntIterable.java
@@ -21,6 +21,7 @@ package com.iabtcf.utils;
  */
 
 import java.util.BitSet;
+import java.util.Collection;
 import java.util.NoSuchElementException;
 
 /**
@@ -53,6 +54,12 @@ public class BitSetIntIterable extends IntIterable {
         for (int i = 0; i < values.length; i++) {
             bs.set(values[i]);
         }
+        return new BitSetIntIterable(bs);
+    }
+
+    public static BitSetIntIterable from(final Collection<Integer> values) {
+        BitSet bs = new BitSet();
+        values.forEach(bs::set);
         return new BitSetIntIterable(bs);
     }
 

--- a/iabtcf-decoder/src/test/java/com/iabtcf/utils/BitSetIntIterableTest.java
+++ b/iabtcf-decoder/src/test/java/com/iabtcf/utils/BitSetIntIterableTest.java
@@ -26,6 +26,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.Arrays;
 import java.util.BitSet;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
 import java.util.TreeSet;
@@ -184,6 +185,19 @@ public class BitSetIntIterableTest {
     @Test
     public void testOf() {
         BitSetIntIterable e = BitSetIntIterable.from(1, 2, 3);
+        assertStreamEquals(new TreeSet<>(Arrays.asList(1, 2, 3)).stream(), e.toStream());
+    }
+
+    @Test
+    public void testOfCollection() {
+        //given
+        final Set<Integer> input = new HashSet<>();
+        input.add(1);
+        input.add(2);
+        input.add(3);
+        //when
+        BitSetIntIterable e = BitSetIntIterable.from(input);
+        //then
         assertStreamEquals(new TreeSet<>(Arrays.asList(1, 2, 3)).stream(), e.toStream());
     }
 


### PR DESCRIPTION
This is a small improvement. If I have user consents gathered in a form of Set<Integer> I would like to have a build-in option to use it directly to encode the TCString