### PR TITLE
ISSUE-94: removing the padding while encoding into a tcf string to make it url and web safe

### DIFF
--- a/iabtcf-encoder/src/main/java/com/iabtcf/encoder/BitWriter.java
+++ b/iabtcf-encoder/src/main/java/com/iabtcf/encoder/BitWriter.java
@@ -252,6 +252,6 @@ class BitWriter {
      * Returns a base64 url encoded representation of the bit array.
      */
     public String toBase64() {
-        return Base64.getUrlEncoder().encodeToString(this.toByteArray());
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(this.toByteArray());
     }
 }

--- a/iabtcf-encoder/src/test/java/com/iabtcf/encoder/BitWriterTest.java
+++ b/iabtcf-encoder/src/test/java/com/iabtcf/encoder/BitWriterTest.java
@@ -29,7 +29,6 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import java.time.Instant;
-import java.util.Base64;
 
 import org.junit.Test;
 
@@ -282,10 +281,9 @@ public class BitWriterTest {
         bw.write(false);
         bw.write(BitSetIntIterable.from(1, 25, 30), 32);
 
-        byte[] rv = bw.toByteArray();
-        String str = Base64.getUrlEncoder().encodeToString(rv);
+        String str = bw.toBase64();
 
-        assertEquals("BOOzQoAOOzQoAAPAFSENCW-AIBACBAAABCA=", str);
+        assertEquals("BOOzQoAOOzQoAAPAFSENCW-AIBACBAAABCA", str);
     }
 
     @Test
@@ -332,8 +330,7 @@ public class BitWriterTest {
         bw.write(0, 12);
         bw.write(false);
 
-        byte[] rv = bw.toByteArray();
-        String str = Base64.getUrlEncoder().encodeToString(rv);
+        String str = bw.toBase64();
 
         assertEquals("COtybn4PA_zT4KjACBENAPCIAEBAAECAAIAAAAAAAAAA", str);
 
@@ -379,7 +376,7 @@ public class BitWriterTest {
         bw1.write(bw3);
 
         // verify
-        String str = Base64.getUrlEncoder().encodeToString(bw1.toByteArray());
+        String str = bw1.toBase64();
         tcModel = TCString.decode(str, DecoderOption.LAZY);
 
         assertEquals(2, tcModel.getVersion());


### PR DESCRIPTION
removing the padding while encoding into a tcf string to make it url and web safe