### PR TITLE
Changing the cookieMaxAgeSeconds field in GVL to long 

### DIFF
--- a/iabtcf-extras-jackson/src/main/java/com/iabtcf/extras/jackson/gvl/Vendor.java
+++ b/iabtcf-extras-jackson/src/main/java/com/iabtcf/extras/jackson/gvl/Vendor.java
@@ -39,7 +39,7 @@ public class Vendor implements com.iabtcf.extras.gvl.Vendor {
     private String policyUrl;
     private Instant deletedDate;
     private com.iabtcf.extras.gvl.Overflow overflow;
-    private Integer cookieMaxAgeSeconds;
+    private Long cookieMaxAgeSeconds;
     private boolean usesCookies;
     private boolean cookieRefresh;
     private boolean usesNonCookieAccess;
@@ -182,7 +182,7 @@ public class Vendor implements com.iabtcf.extras.gvl.Vendor {
      * cookie method of storage.
      */
     @Override
-    public Optional<Integer> getCookieMaxAgeSeconds() {
+    public Optional<Long> getCookieMaxAgeSeconds() {
         return Optional.ofNullable(cookieMaxAgeSeconds);
     }
 

--- a/iabtcf-extras-jackson/src/test/java/com/iabtcf/extras/jackson/gvl/VendorTest.java
+++ b/iabtcf-extras-jackson/src/test/java/com/iabtcf/extras/jackson/gvl/VendorTest.java
@@ -121,9 +121,9 @@ public class VendorTest {
 
     @Test
     public void testCookieMaxAgeSeconds() {
-        int expectedCookieMaxAgeSeconds = 2678400;
+        long expectedCookieMaxAgeSeconds = 31557600000L;
         Assert.assertTrue(vendorEight.getCookieMaxAgeSeconds().isPresent());
-        Assert.assertEquals(expectedCookieMaxAgeSeconds, vendorEight.getCookieMaxAgeSeconds().get().intValue());
+        Assert.assertEquals(expectedCookieMaxAgeSeconds, vendorEight.getCookieMaxAgeSeconds().get().longValue());
     }
 
     @Test

--- a/iabtcf-extras-jackson/src/test/resources/gvl.json
+++ b/iabtcf-extras-jackson/src/test/resources/gvl.json
@@ -626,7 +626,7 @@
       "overflow": {
         "httpGetLimit": 32
       },
-      "cookieMaxAgeSeconds": 2678400,
+      "cookieMaxAgeSeconds": 31557600000,
       "usesCookies": true,
       "cookieRefresh": false,
       "usesNonCookieAccess": true

--- a/iabtcf-extras/src/main/java/com/iabtcf/extras/gvl/Vendor.java
+++ b/iabtcf-extras/src/main/java/com/iabtcf/extras/gvl/Vendor.java
@@ -130,7 +130,7 @@ public interface Vendor {
      * Note: this only includes what is declared when the storage is set and does not consider duration extensions
      * should storage be refreshed
      */
-    Optional<Integer> getCookieMaxAgeSeconds();
+    Optional<Long> getCookieMaxAgeSeconds();
 
     /**
      * This boolean field indicates whether the vendor uses cookie storage (session or otherwise).


### PR DESCRIPTION
currently the specification says it's an integer but there is no max value set on it.